### PR TITLE
Change internal robot names BUNNYBOT -> DORY and LIGHTCYCLE -> NAUTILUS

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -14,7 +14,7 @@ import edu.wpi.first.wpilibj.DigitalInput;
  */
 public final class Constants {
   public static final DigitalInput robotJumper = new DigitalInput(0);
-  public static final Robot currentRobot = Robot.BUNNYBOT;
+  public static final Robot currentRobot = Robot.DORY;
   public static final Mode currentMode = Mode.REAL;
 
   public static enum Mode {
@@ -29,8 +29,8 @@ public final class Constants {
   }
 
   public enum Robot {
-    BUNNYBOT,
-    LIGHTCYCLE
+    DORY,
+    NAUTILUS
   }
 
   public static final double UPDATE_PERIOD = 0.02;
@@ -71,14 +71,14 @@ public final class Constants {
 
       public static final Rotation2d[] absoluteEncoderOffset =
           switch (currentRobot) {
-            case BUNNYBOT ->
+            case DORY ->
                 new Rotation2d[] {
                   Rotation2d.fromRadians(2.291767297101148), // FL
                   Rotation2d.fromRadians(2.409883817768342 + Math.PI), // FR
                   Rotation2d.fromRadians(1.928213850372251), // BL
                   Rotation2d.fromRadians(1.73493227109866 + Math.PI) // BR
                 };
-            case LIGHTCYCLE ->
+            case NAUTILUS ->
                 new Rotation2d[] { // This is not currently correct
                   Rotation2d.fromRadians(2.6599226861937018), // FL
                   Rotation2d.fromRadians(-2.9206994201342606 + Math.PI), // FR

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
@@ -54,9 +54,9 @@ public class GyroIONavX implements GyroIO {
                 (Double value) ->
                     Rotation2d.fromDegrees(
                         switch (currentRobot) {
-                          case BUNNYBOT ->
+                          case DORY ->
                               -value; // According to last years code, clef NavX is inverted
-                          case LIGHTCYCLE -> -value;
+                          case NAUTILUS -> -value;
                         }))
             .toArray(Rotation2d[]::new);
     yawTimestampQueue.clear();


### PR DESCRIPTION
Change the names of the robots as defined in Constants from bunnybots names to FRC 2025 names (BUNNYBOT -> DORY, LIGHTCYCLE -> NAUTILUS). 
Note that this will probably require (somewhat manual) refactoring on almost all development branches.