### PR TITLE
Modify ModuleIOSim's motor systems so it doesn't throw exceptions

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
@@ -36,9 +36,11 @@ public class ModuleIOSim implements ModuleIO {
   private static final double LOOP_PERIOD_SECS = 0.02;
 
   private final DCMotorSim driveSim =
-      new DCMotorSim(LinearSystemId.createDCMotorSystem(0, 0), DCMotor.getKrakenX60(0), 0.025);
+      new DCMotorSim(
+          LinearSystemId.createDCMotorSystem(2.0, 0.01), DCMotor.getKrakenX60(1), 0.025, 0.025);
   private final DCMotorSim turnSim =
-      new DCMotorSim(LinearSystemId.createDCMotorSystem(0, 0), DCMotor.getNEO(1), 150.0 / 7.0);
+      new DCMotorSim(
+          LinearSystemId.createDCMotorSystem(2.0, 0.01), DCMotor.getKrakenX60(1), .004, .004);
 
   private final SimpleMotorFeedforward motorFF = new SimpleMotorFeedforward(0.0, 2.0, 0.01);
   private final PIDController turnPID = new PIDController(75.0, 0.0, 0.0);


### PR DESCRIPTION
Resolve #9, ModuleIOSim throwing exceptions due to changes to `DCMotorSim`'s constructor between WPILib 2024 and 2025. It's a little janky (motors jitter a decent amount and sometimes rotate weirdly) but probably acceptable for simulation.