### PR TITLE
Add Spotless check to CI

### DIFF
--- a/.github/workflows/spotless_check.yml
+++ b/.github/workflows/spotless_check.yml
@@ -1,0 +1,19 @@
+name: Spotless Check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Spotless Check
+    runs-on: ubuntu-latest
+    container: wpilib/roborio-cross-ubuntu:2025-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Grant execute permission to gradlew
+        run: chmod +x gradlew
+      - name: Run SpotlessCheck
+        run: ./gradlew SpotlessCheck

--- a/src/test/java/ReefTargetsTest.java
+++ b/src/test/java/ReefTargetsTest.java
@@ -91,6 +91,5 @@ public final class ReefTargetsTest {
     } catch (AssertionError e) {
       System.out.println(e.getMessage());
     }
-
   }
 }


### PR DESCRIPTION
Run `gradlew SpotlessCheck` on push, PR, and manually. This ensures that all code merged to main will be Spotless compliant.