### PR TITLE
Update WPILib to 2025.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.2.1"
+    id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id "com.peterabeles.gversion" version "1.10"
     id "com.diffplug.spotless" version "7.0.2"
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,5 +1,7 @@
 package frc.robot;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DigitalInput;
@@ -13,6 +15,13 @@ import edu.wpi.first.wpilibj.DigitalInput;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+  // TODO Make it more clear/easier that we need to switch this per comp.
+  /**
+   * The layout of the april tags on the field. This must be updated depending on the comp we're on.
+   */
+  public static final AprilTagFieldLayout aprilTagLayout =
+      AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);
+
   public static final DigitalInput robotJumper = new DigitalInput(0);
 
   public static final Robot currentRobot =

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -15,9 +15,9 @@ import edu.wpi.first.wpilibj.DigitalInput;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-  // TODO Make it more clear/easier that we need to switch this per comp.
   /**
-   * The layout of the april tags on the field. This must be updated depending on the comp we're on.
+   * The layout of the april tags on the field. Comps in PNW should use welded, and the differences
+   * between welded and AndyMark are very small.
    */
   public static final AprilTagFieldLayout aprilTagLayout =
       AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);

--- a/src/main/java/frc/robot/util/ReefTargets.java
+++ b/src/main/java/frc/robot/util/ReefTargets.java
@@ -4,8 +4,8 @@
 
 package frc.robot.util;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.apriltag.AprilTagFields;
+import static frc.robot.Constants.aprilTagLayout;
+
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
@@ -13,9 +13,6 @@ import frc.robot.Constants.DriveConstants.reefTargetConstants;
 
 public final class ReefTargets {
 
-  // Define AprilTag layout
-  final AprilTagFieldLayout aprilTagFieldLayout =
-      AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
   final Pose2d[] targets = new Pose2d[12];
 
   public ReefTargets() {
@@ -30,18 +27,18 @@ public final class ReefTargets {
 
     // Defines each target position based upon the transformation vector and appropriate apriltag
     // 17 -> 1,2; 18 -> 0,11; 19 -> 9,10; 20 -> 7,8; 21 -> 5,6; 22 -> 3,4
-    targets[0] = aprilTagFieldLayout.getTagPose(18).get().toPose2d().transformBy(targetL);
-    targets[1] = aprilTagFieldLayout.getTagPose(17).get().toPose2d().transformBy(targetR);
-    targets[2] = aprilTagFieldLayout.getTagPose(17).get().toPose2d().transformBy(targetL);
-    targets[3] = aprilTagFieldLayout.getTagPose(22).get().toPose2d().transformBy(targetR);
-    targets[4] = aprilTagFieldLayout.getTagPose(22).get().toPose2d().transformBy(targetL);
-    targets[5] = aprilTagFieldLayout.getTagPose(21).get().toPose2d().transformBy(targetR);
-    targets[6] = aprilTagFieldLayout.getTagPose(21).get().toPose2d().transformBy(targetL);
-    targets[7] = aprilTagFieldLayout.getTagPose(20).get().toPose2d().transformBy(targetR);
-    targets[8] = aprilTagFieldLayout.getTagPose(20).get().toPose2d().transformBy(targetL);
-    targets[9] = aprilTagFieldLayout.getTagPose(19).get().toPose2d().transformBy(targetR);
-    targets[10] = aprilTagFieldLayout.getTagPose(19).get().toPose2d().transformBy(targetL);
-    targets[11] = aprilTagFieldLayout.getTagPose(18).get().toPose2d().transformBy(targetR);
+    targets[0] = aprilTagLayout.getTagPose(18).get().toPose2d().transformBy(targetL);
+    targets[1] = aprilTagLayout.getTagPose(17).get().toPose2d().transformBy(targetR);
+    targets[2] = aprilTagLayout.getTagPose(17).get().toPose2d().transformBy(targetL);
+    targets[3] = aprilTagLayout.getTagPose(22).get().toPose2d().transformBy(targetR);
+    targets[4] = aprilTagLayout.getTagPose(22).get().toPose2d().transformBy(targetL);
+    targets[5] = aprilTagLayout.getTagPose(21).get().toPose2d().transformBy(targetR);
+    targets[6] = aprilTagLayout.getTagPose(21).get().toPose2d().transformBy(targetL);
+    targets[7] = aprilTagLayout.getTagPose(20).get().toPose2d().transformBy(targetR);
+    targets[8] = aprilTagLayout.getTagPose(20).get().toPose2d().transformBy(targetL);
+    targets[9] = aprilTagLayout.getTagPose(19).get().toPose2d().transformBy(targetR);
+    targets[10] = aprilTagLayout.getTagPose(19).get().toPose2d().transformBy(targetL);
+    targets[11] = aprilTagLayout.getTagPose(18).get().toPose2d().transformBy(targetR);
   }
 
   public int findClosestReef(Pose2d robotCurrentPosition) {


### PR DESCRIPTION
Update WPILib from from 2025.2.1 to 2025.3.1.
This will allow us to use the new april tag layouts defined in [TU12](https://firstfrc.blob.core.windows.net/frc2025/Manual/TeamUpdates/TeamUpdate12.pdf).