### PR TITLE
Retune steering

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -142,10 +142,10 @@ public class ModuleIOTalonFX implements ModuleIO {
     driveConfig.Feedback.SensorToMechanismRatio =
         (DRIVE_GEAR_RATIO) * (1.0 / (WHEEL_RADIUS * 2 * Math.PI));
 
-    driveConfig.Slot0.kV = 2.28;
-    driveConfig.Slot0.kA = 0.08;
-    driveConfig.Slot0.kS = 0.25;
-    driveConfig.Slot0.kP = 7.5; // TODO hand tune
+    driveConfig.Slot0.kV = 0.37914;
+    driveConfig.Slot0.kA = 0.013797;
+    driveConfig.Slot0.kS = 0.37914;
+    driveConfig.Slot0.kP = 0.54716; // TODO hand tune
     driveConfig.Slot0.kD = 0.005;
 
     driveTalon.getConfigurator().apply(driveConfig);


### PR DESCRIPTION
Use tuned swerve values derived from sysid a few weeks ago.

Tested on Nautilus and work very well, and it should be not overly harmful to deploy to Dory.