### PR TITLE
Changed vision standard deviation logic

### DIFF
--- a/src/main/java/frc/robot/constants/VisionConstants.java
+++ b/src/main/java/frc/robot/constants/VisionConstants.java
@@ -10,6 +10,9 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+
+import java.util.Queue;
+
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 public class VisionConstants {
@@ -105,11 +108,31 @@ public class VisionConstants {
                 Units.degreesToRadians(-147)));
   }
 
-  public static final Matrix<N3, N1> highResSingleTagStdDev =
+    /** Standard Deviations for when we see a single target with a high resolution camera.*/
+    public static final Matrix<N3, N1> highResSingleTagStdDev =
       VecBuilder.fill(0.4, 0.4, Double.MAX_VALUE);
-  public static final Matrix<N3, N1> normalSingleTagStdDev =
+
+    /** Maximum distance to trust data when we see a single target with a high resolution camera. */
+    public static final double highResSingleTagMaxDist = 5; // TODO get new value
+
+    /** Standard Deviations for when we see a single target with a normal resolution camera.*/
+    public static final Matrix<N3, N1> normalSingleTagStdDev =
       VecBuilder.fill(0.8, 0.8, Double.MAX_VALUE);
-  public static final Matrix<N3, N1> highResMultiTagStdDev = VecBuilder.fill(0.2, 0.2, 3);
-  public static final Matrix<N3, N1> normalMultiTagStdDev =
+
+    /** Maximum distance to trust data when we see a single target with a normal resolution camera. */
+    public static final double normalSingleTagMaxDist = 5; // TODO get new value
+
+    /** Standard Deviations for when we see multiple targets with a high resolution camera.*/
+    public static final Matrix<N3, N1> highResMultiTagStdDev = 
+        VecBuilder.fill(0.2, 0.2, 3);
+
+    /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
+    public static final double highResMultiTagMaxDist = 5; // TODO get new value
+
+    /** Standard Deviations for when we see multiple targets with a normal resolution camera.*/
+    public static final Matrix<N3, N1> normalMultiTagStdDev =
       VecBuilder.fill(0.5, 0.5, Double.MAX_VALUE);
+
+    /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
+    public static final double normalMultiTagMaxDist = 5; // TODO get new value
 }

--- a/src/main/java/frc/robot/constants/VisionConstants.java
+++ b/src/main/java/frc/robot/constants/VisionConstants.java
@@ -10,9 +10,6 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
-
-import java.util.Queue;
-
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 public class VisionConstants {
@@ -108,31 +105,30 @@ public class VisionConstants {
                 Units.degreesToRadians(-147)));
   }
 
-    /** Standard Deviations for when we see a single target with a high resolution camera.*/
-    public static final Matrix<N3, N1> highResSingleTagStdDev =
+  /** Standard Deviations for when we see a single target with a high resolution camera. */
+  public static final Matrix<N3, N1> highResSingleTagStdDev =
       VecBuilder.fill(0.4, 0.4, Double.MAX_VALUE);
 
-    /** Maximum distance to trust data when we see a single target with a high resolution camera. */
-    public static final double highResSingleTagMaxDist = 5; // TODO get new value
+  /** Maximum distance to trust data when we see a single target with a high resolution camera. */
+  public static final double highResSingleTagMaxDist = 5; // TODO get new value
 
-    /** Standard Deviations for when we see a single target with a normal resolution camera.*/
-    public static final Matrix<N3, N1> normalSingleTagStdDev =
+  /** Standard Deviations for when we see a single target with a normal resolution camera. */
+  public static final Matrix<N3, N1> normalSingleTagStdDev =
       VecBuilder.fill(0.8, 0.8, Double.MAX_VALUE);
 
-    /** Maximum distance to trust data when we see a single target with a normal resolution camera. */
-    public static final double normalSingleTagMaxDist = 5; // TODO get new value
+  /** Maximum distance to trust data when we see a single target with a normal resolution camera. */
+  public static final double normalSingleTagMaxDist = 5; // TODO get new value
 
-    /** Standard Deviations for when we see multiple targets with a high resolution camera.*/
-    public static final Matrix<N3, N1> highResMultiTagStdDev = 
-        VecBuilder.fill(0.2, 0.2, 3);
+  /** Standard Deviations for when we see multiple targets with a high resolution camera. */
+  public static final Matrix<N3, N1> highResMultiTagStdDev = VecBuilder.fill(0.2, 0.2, 3);
 
-    /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
-    public static final double highResMultiTagMaxDist = 5; // TODO get new value
+  /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
+  public static final double highResMultiTagMaxDist = 5; // TODO get new value
 
-    /** Standard Deviations for when we see multiple targets with a normal resolution camera.*/
-    public static final Matrix<N3, N1> normalMultiTagStdDev =
+  /** Standard Deviations for when we see multiple targets with a normal resolution camera. */
+  public static final Matrix<N3, N1> normalMultiTagStdDev =
       VecBuilder.fill(0.5, 0.5, Double.MAX_VALUE);
 
-    /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
-    public static final double normalMultiTagMaxDist = 5; // TODO get new value
+  /** Maximum distance to trust data when we see multiple targets with a high resolution camera. */
+  public static final double normalMultiTagMaxDist = 5; // TODO get new value
 }

--- a/src/main/java/frc/robot/subsystems/apriltagvision/AprilTagVisionIO.java
+++ b/src/main/java/frc/robot/subsystems/apriltagvision/AprilTagVisionIO.java
@@ -69,34 +69,28 @@ public interface AprilTagVisionIO {
               .getNorm();
     }
 
+    // If we see no tags, return inf
     if (numTags == 0) return VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
     avgDist /= numTags;
 
-    // Decrease std devs if multiple targets are visible
-    if (numTags > 1
-        && avgDist
-            > switch (resolution) {
-              case HIGH_RES -> 8;
-              case NORMAL -> 5;
-            }) {
+    // Set stdDevConstant based on resolution and tag count
+    Matrix<N3, N1> stdDevConstant = switch(resolution) {
+      case HIGH_RES -> (numTags == 1) ? highResSingleTagStdDev : highResMultiTagStdDev;
+      case NORMAL -> (numTags == 1) ? normalSingleTagStdDev : normalMultiTagStdDev;
+    };
+    // Set max distance based on resolution and tag count
+    double maxDistance = switch(resolution) {
+      case HIGH_RES -> (numTags == 1) ? highResSingleTagMaxDist : highResMultiTagMaxDist;
+      case NORMAL -> (numTags == 1) ? normalSingleTagMaxDist : normalMultiTagMaxDist;
+    };
+
+    // If the average distance is larger than the max distance, return inf
+    if (avgDist > maxDistance) {
       estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+
+    // otherwise return stdDev multiplies by distance squared
     } else {
-      estStdDevs =
-          switch (resolution) {
-            case HIGH_RES -> highResMultiTagStdDev;
-            case NORMAL -> normalMultiTagStdDev;
-          };
-    }
-    // Increase std devs based on (average) distance
-    if (numTags == 1
-        && avgDist
-            > switch (resolution) {
-              case HIGH_RES -> 3;
-              case NORMAL -> 2;
-            }) {
-      estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-    } else {
-      estStdDevs = estStdDevs.times(1 + (avgDist * avgDist * avgDist / 20));
+      estStdDevs = stdDevConstant.times(Math.pow(avgDist, 2));
     }
 
     return estStdDevs;

--- a/src/main/java/frc/robot/subsystems/apriltagvision/AprilTagVisionIO.java
+++ b/src/main/java/frc/robot/subsystems/apriltagvision/AprilTagVisionIO.java
@@ -74,21 +74,23 @@ public interface AprilTagVisionIO {
     avgDist /= numTags;
 
     // Set stdDevConstant based on resolution and tag count
-    Matrix<N3, N1> stdDevConstant = switch(resolution) {
-      case HIGH_RES -> (numTags == 1) ? highResSingleTagStdDev : highResMultiTagStdDev;
-      case NORMAL -> (numTags == 1) ? normalSingleTagStdDev : normalMultiTagStdDev;
-    };
+    Matrix<N3, N1> stdDevConstant =
+        switch (resolution) {
+          case HIGH_RES -> (numTags == 1) ? highResSingleTagStdDev : highResMultiTagStdDev;
+          case NORMAL -> (numTags == 1) ? normalSingleTagStdDev : normalMultiTagStdDev;
+        };
     // Set max distance based on resolution and tag count
-    double maxDistance = switch(resolution) {
-      case HIGH_RES -> (numTags == 1) ? highResSingleTagMaxDist : highResMultiTagMaxDist;
-      case NORMAL -> (numTags == 1) ? normalSingleTagMaxDist : normalMultiTagMaxDist;
-    };
+    double maxDistance =
+        switch (resolution) {
+          case HIGH_RES -> (numTags == 1) ? highResSingleTagMaxDist : highResMultiTagMaxDist;
+          case NORMAL -> (numTags == 1) ? normalSingleTagMaxDist : normalMultiTagMaxDist;
+        };
 
     // If the average distance is larger than the max distance, return inf
     if (avgDist > maxDistance) {
       estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
 
-    // otherwise return stdDev multiplies by distance squared
+      // otherwise return stdDev multiplies by distance squared
     } else {
       estStdDevs = stdDevConstant.times(Math.pow(avgDist, 2));
     }


### PR DESCRIPTION
Changed the logic for calculating standard deviation as discussed Wednesday night. Now just calculates the standard deviation by multiplying a multi tag or single tag constant by the square of the average distance from all of the tags.

TODO

- [ ] Test on Nautilus
- [ ] Find new Std Dev values
- [ ] Find new max distance values