### PR TITLE
Minor tweaks made at Chicken Coop

### DIFF
--- a/src/main/java/frc/robot/constants/PositionConstants.java
+++ b/src/main/java/frc/robot/constants/PositionConstants.java
@@ -15,7 +15,7 @@ public class PositionConstants {
   // placeholders)
   // Origin to bumper ~0.4572 m
 
-  public static final double[] reefOffsetsX = {0.4572, 0.4572, 0.4572, 0.4572};
+  public static final double[] reefOffsetsX = {0.4318, 0.4318, 0.4318, 0.4318};
   public static final double reefOffsetY = 0.1793875;
 
   public static final double reefRobotAngle = Radians.convertFrom(180, Degrees);

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
@@ -35,6 +35,9 @@ public interface ModuleIO {
     public Rotation2d[] odometryTurnPositions = new Rotation2d[] {};
 
     public boolean moduleDataValid = true;
+
+    public double driveMotorTemp = 0.0;
+    public double turnMotorTemp = 0.0;
   }
 
   /** Updates the set of loggable inputs. */

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -275,6 +275,9 @@ public class ModuleIOTalonFX implements ModuleIO {
     timestampQueue.clear();
     drivePositionQueue.clear();
     turnPositionQueue.clear();
+
+    inputs.driveMotorTemp = driveTalon.getDeviceTemp().getValueAsDouble();
+    inputs.turnMotorTemp = turnTalon.getDeviceTemp().getValueAsDouble();
   }
 
   @Override

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -106,8 +106,7 @@ public class CompoundCommands {
     Command alignCommand =
         new ParallelCommandGroup(driveCommand, armToReef(level)).withTimeout(5.0);
 
-    // Wait after alignment so drivers can A-Stop if needed.
-    return alignCommand.andThen(waitSeconds(3.0)).andThen(ejectCoral());
+    return alignCommand.andThen(ejectCoral());
   }
 
   public static Command intakeSource(boolean isOnRight) {
@@ -119,7 +118,7 @@ public class CompoundCommands {
     }
 
     Command alignCommand = new ParallelCommandGroup(driveCommand, armToSource());
-    return alignCommand.andThen(intakeCoral());
+    return alignCommand.alongWith(intakeCoral());
   }
 
   /**

--- a/src/main/java/frc/robot/util/PathGenerator.java
+++ b/src/main/java/frc/robot/util/PathGenerator.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.constants.PathingConstants;
 import frc.robot.subsystems.drive.Drive;
 import java.util.List;
+import org.littletonrobotics.junction.Logger;
 
 public class PathGenerator {
   /**
@@ -144,8 +145,14 @@ public class PathGenerator {
                   drive.getPose().getTranslation().getDistance(target.getTranslation());
               double rotationError =
                   Math.abs(drive.getPose().getRotation().minus(target.getRotation()).getRadians());
-              return translationError < translationTolerance
-                  && rotationError < rotationTolerance.getRadians();
+              boolean inTolerance =
+                  translationError < translationTolerance
+                      && rotationError < rotationTolerance.getRadians();
+              Logger.recordOutput("/Pathing/inAcceptableError", inTolerance);
+              Logger.recordOutput("/Pathing/translationError", translationError);
+              Logger.recordOutput("/Pathing/rotationError", rotationError);
+
+              return inTolerance;
             })
         .finallyDo(
             () -> {

--- a/src/test/java/ReefTargetsTest.java
+++ b/src/test/java/ReefTargetsTest.java
@@ -21,7 +21,7 @@ public final class ReefTargetsTest {
     // AprilTag 18
     try {
       assertPoseWithin(
-          new Pose2d(3.200, 4.205, Rotation2d.fromDegrees(0)),
+          new Pose2d(3.2258, 4.205, Rotation2d.fromDegrees(0)),
           reefTargetsBlue.getReefPose(false, new Pose2d(3.5, 4, new Rotation2d(0)), 4, 0.0),
           "\n Left L4, (3.5, 4), Coral 0.0, AprilTag 18",
           tolerance);
@@ -30,7 +30,7 @@ public final class ReefTargetsTest {
     }
     try {
       assertPoseWithin(
-          new Pose2d(3.200, 3.705, Rotation2d.fromDegrees(0)),
+          new Pose2d(3.2258, 3.705, Rotation2d.fromDegrees(0)),
           reefTargetsBlue.getReefPose(false, new Pose2d(3.5, 4, new Rotation2d(0)), 4, 0.5),
           "Left L4, (3.5, 4), Coral 0.5, AprilTag 18",
           tolerance);
@@ -39,7 +39,7 @@ public final class ReefTargetsTest {
     }
     try {
       assertPoseWithin(
-          new Pose2d(3.200, 3.847, Rotation2d.fromDegrees(0)),
+          new Pose2d(3.2258, 3.847, Rotation2d.fromDegrees(0)),
           reefTargetsBlue.getReefPose(true, new Pose2d(3.5, 4, Rotation2d.fromDegrees(0)), 4, 0.0),
           "Right L4, (3.5, 4), Coral 0.0, AprilTag 18",
           tolerance);
@@ -48,7 +48,7 @@ public final class ReefTargetsTest {
     }
     try {
       assertPoseWithin(
-          new Pose2d(3.200, 3.347, Rotation2d.fromDegrees(0)),
+          new Pose2d(3.2258, 3.347, Rotation2d.fromDegrees(0)),
           reefTargetsBlue.getReefPose(true, new Pose2d(3.5, 4, Rotation2d.fromDegrees(0)), 4, 0.5),
           "Right L4, (3.5, 4), Coral 0.5, AprilTag 18",
           tolerance);
@@ -58,7 +58,7 @@ public final class ReefTargetsTest {
     // AprilTag 19
     try {
       assertPoseWithin(
-          new Pose2d(4.001, 5.231, Rotation2d.fromDegrees(-60)),
+          new Pose2d(4.01336013212138, 5.209, Rotation2d.fromDegrees(-60)),
           reefTargetsBlue.getReefPose(
               false, new Pose2d(4, 4.5, Rotation2d.fromDegrees(-60)), 4, 0.0),
           "\n Left L4, (4, 4.5), Coral 0.0, AprilTag 19",
@@ -68,7 +68,7 @@ public final class ReefTargetsTest {
     }
     try {
       assertPoseWithin(
-          new Pose2d(3.568, 4.981, Rotation2d.fromDegrees(-60)),
+          new Pose2d(3.580347430229161, 4.959, Rotation2d.fromDegrees(-60)),
           reefTargetsBlue.getReefPose(false, new Pose2d(4, 4.5, Rotation2d.fromDegrees(0)), 4, 0.5),
           "Left L4, (4, 4.5), Coral 0.5, AprilTag 19",
           tolerance);
@@ -78,7 +78,7 @@ public final class ReefTargetsTest {
     // AprilTag 21
     try {
       assertPoseWithin(
-          new Pose2d(5.778, 4.205, Rotation2d.fromDegrees(180)),
+          new Pose2d(5.752846, 4.205, Rotation2d.fromDegrees(180)),
           reefTargetsBlue.getReefPose(true, new Pose2d(5, 4, Rotation2d.fromDegrees(0)), 4, 0.0),
           "\n Right L4, (5, 4), Coral 0.0, AprilTag 21",
           tolerance);
@@ -87,7 +87,7 @@ public final class ReefTargetsTest {
     }
     try {
       assertPoseWithin(
-          new Pose2d(5.778, 4.705, Rotation2d.fromDegrees(180)),
+          new Pose2d(5.752846, 4.705, Rotation2d.fromDegrees(180)),
           reefTargetsBlue.getReefPose(true, new Pose2d(5, 4, Rotation2d.fromDegrees(0)), 4, 0.5),
           "Right L4, (5, 4), Coral 0.5, AprilTag 21",
           tolerance);
@@ -97,7 +97,7 @@ public final class ReefTargetsTest {
 
     try {
       assertPoseWithin(
-          new Pose2d(5.778, 4.205, Rotation2d.fromDegrees(180)),
+          new Pose2d(5.752, 4.205, Rotation2d.fromDegrees(180)),
           reefTargetsBlue.getReefPose(true, new Pose2d(5, 4, Rotation2d.fromDegrees(0)), 1, 0.5),
           "\n Right L1, (5, 4), Coral 0.0, AprilTag 21",
           tolerance);


### PR DESCRIPTION
Minor tweaks that were made at the Chicken Coop Wednesday.

**Note that this does not include all modifications made that day. Modifications in separate branches/PRs are:**

- [X] Move reef pole on 2 piece auto routine (branch `two-piece-auto`)
- [X] Buttons on operator controller for intake/eject without moving arm (PR #55)
- [ ] Change auto commands to better integrate stow positions as done in 3aa83b3a221731fd0f0764e4d79957d8810963c3 (PR #46)