### PR TITLE
Dcmp tweaks

### DIFF
--- a/src/main/deploy/pathplanner/autos/0 - L.auto
+++ b/src/main/deploy/pathplanner/autos/0 - L.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "Mobility Left"

--- a/src/main/deploy/pathplanner/autos/0 - M.auto
+++ b/src/main/deploy/pathplanner/autos/0 - M.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "Mobility Center"

--- a/src/main/deploy/pathplanner/autos/0 - R.auto
+++ b/src/main/deploy/pathplanner/autos/0 - R.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "Mobility Right"

--- a/src/main/deploy/pathplanner/autos/1 - L.auto
+++ b/src/main/deploy/pathplanner/autos/1 - L.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "Left - Reef Left"
@@ -14,6 +20,12 @@
           "type": "named",
           "data": {
             "name": "AutoPlaceRight4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ArmToStow"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/1 - M PoleR.auto
+++ b/src/main/deploy/pathplanner/autos/1 - M PoleR.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "Center - ReefCenter"
@@ -14,6 +20,12 @@
           "type": "named",
           "data": {
             "name": "AutoPlaceRight4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ArmToStow"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/1 - R.auto
+++ b/src/main/deploy/pathplanner/autos/1 - R.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "2 Piece Center Right.0"
@@ -14,6 +20,12 @@
           "type": "named",
           "data": {
             "name": "AutoPlaceLeft4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ArmToStow"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/2 - L.auto
+++ b/src/main/deploy/pathplanner/autos/2 - L.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "2 - L.0"
@@ -51,6 +57,12 @@
           "type": "named",
           "data": {
             "name": "AutoPlaceLeft4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ArmToStow"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/2 - R.auto
+++ b/src/main/deploy/pathplanner/autos/2 - R.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "ZeroWrist"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "2 Piece Center Right.0"
@@ -63,6 +69,12 @@
           "type": "named",
           "data": {
             "name": "AutoPlaceRight4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ArmToStow"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/Pit Test.auto
+++ b/src/main/deploy/pathplanner/autos/Pit Test.auto
@@ -5,21 +5,15 @@
     "data": {
       "commands": [
         {
-          "type": "named",
+          "type": "wait",
           "data": {
-            "name": "ZeroWrist"
-          }
-        },
-        {
-          "type": "path",
-          "data": {
-            "pathName": "Center - ReefCenter"
+            "waitTime": 5.0
           }
         },
         {
           "type": "named",
           "data": {
-            "name": "AutoPlaceLeft4"
+            "name": "TestPlaceReefImmobile"
           }
         },
         {

--- a/src/main/deploy/pathplanner/autos/Pit Test.auto
+++ b/src/main/deploy/pathplanner/autos/Pit Test.auto
@@ -5,12 +5,6 @@
     "data": {
       "commands": [
         {
-          "type": "wait",
-          "data": {
-            "waitTime": 5.0
-          }
-        },
-        {
           "type": "named",
           "data": {
             "name": "TestPlaceReefImmobile"

--- a/src/main/deploy/pathplanner/autos/Pit Test.auto
+++ b/src/main/deploy/pathplanner/autos/Pit Test.auto
@@ -19,7 +19,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": true
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -87,8 +87,6 @@ public class Robot extends LoggedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-
-    m_robotContainer.zeroArm().schedule();
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,12 +23,6 @@ public class Robot extends LoggedRobot {
 
   @Override
   public void robotInit() {
-
-    Logger.addDataReceiver(new WPILOGWriter("U/logs"));
-    Logger.addDataReceiver(new NT4Publisher());
-
-    Logger.start();
-
     m_robotContainer = new RobotContainer();
 
     // Set up data receivers & replay source

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,7 +160,7 @@ public class RobotContainer {
 
     backupController.povDown().onTrue(zeroArm());
 
-    backupController.leftBumper().whileTrue(intake.backEjectCoralCommand());
+    backupController.leftBumper().whileTrue(intake.runEjectCommand());
 
     backupController.rightBumper().whileTrue(intake.intakeCoralCommand());
 
@@ -204,7 +204,7 @@ public class RobotContainer {
         .onFalse(CompoundCommands.armToStowSafely());
     controller
         .rightTrigger(0.25)
-        .whileTrue(intake.intakeCoralCommand())
+        .whileTrue(intake.runEjectCommand())
         .onFalse(
             intake.stopCommand().alongWith(CompoundCommands.armToStowSafely()).andThen(zeroArm()));
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,7 +160,7 @@ public class RobotContainer {
 
     backupController.povDown().onTrue(zeroArm());
 
-    backupController.leftBumper().whileTrue(intake.runEjectCommand());
+    backupController.leftBumper().whileTrue(intake.backEjectCoralCommand());
 
     backupController.rightBumper().whileTrue(intake.intakeCoralCommand());
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,7 +160,7 @@ public class RobotContainer {
 
     backupController.povDown().onTrue(zeroArm());
 
-    backupController.leftBumper().whileTrue(intake.ejectCoralCommand());
+    backupController.leftBumper().whileTrue(intake.backEjectCoralCommand());
 
     backupController.rightBumper().whileTrue(intake.intakeCoralCommand());
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -164,6 +164,12 @@ public class RobotContainer {
 
     backupController.rightBumper().whileTrue(intake.intakeCoralCommand());
 
+    backupController.start().whileTrue(CompoundCommands.armToNet());
+
+    backupController.x().whileTrue(intake.intakeAlgaeCommand());
+
+    backupController.y().whileTrue(intake.ejectAlgaeCommand());
+
     backupController
         .povUp()
         .onTrue(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -198,8 +198,9 @@ public class RobotContainer {
         .onFalse(CompoundCommands.armToStowSafely());
     controller
         .rightTrigger(0.25)
-        .whileTrue(intake.ejectCoralCommand())
-        .onFalse(intake.stopCommand().alongWith(CompoundCommands.armToStow()));
+        .whileTrue(intake.intakeCoralCommand())
+        .onFalse(
+            intake.stopCommand().alongWith(CompoundCommands.armToStowSafely()).andThen(zeroArm()));
 
     controller
         .rightStick()

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -93,7 +93,10 @@ public class ElevatorConstants {
 
   public static final double moveVoltage = 5.0;
 
+  /** Maximum speed of elevator in m/s */
   public static final double MAX_SPEED = 3.6;
+
+  /** Maximum acceleration of elevator in m/s² */
   public static final double MAX_ACCELERATION = 4.0;
 
   /* Device IDs */

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -93,6 +93,9 @@ public class ElevatorConstants {
 
   public static final double moveVoltage = 5.0;
 
+  public static final double MAX_SPEED = 3.6
+  public static final double MAX_ACCELERATION = 4.0
+
   /* Device IDs */
   public static final int motorID = 12;
 

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -93,8 +93,8 @@ public class ElevatorConstants {
 
   public static final double moveVoltage = 5.0;
 
-  public static final double MAX_SPEED = 3.6
-  public static final double MAX_ACCELERATION = 4.0
+  public static final double MAX_SPEED = 3.6;
+  public static final double MAX_ACCELERATION = 4.0;
 
   /* Device IDs */
   public static final int motorID = 12;

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -99,6 +99,9 @@ public class ElevatorConstants {
   /** Maximum acceleration of elevator in m/s² */
   public static final double MAX_ACCELERATION = 4.0;
 
+  /** The motion magic jerk of the elevator in meters */
+  public static final double MOTION_MAGIC_JERK = 0.0;
+
   /* Device IDs */
   public static final int motorID = 12;
 

--- a/src/main/java/frc/robot/constants/IntakeConstants.java
+++ b/src/main/java/frc/robot/constants/IntakeConstants.java
@@ -8,7 +8,11 @@ public class IntakeConstants {
 
   public static final double INTAKE_CORAL_TOP_MOTOR_VOLTAGE = -3;
   public static final double INTAKE_CORAL_LOW_MOTOR_VOLTAGE = 3;
-  public static final double EJECT_CORAL_TOP_MOTOR_VOLTAGE = 4;
+
+  public static final double BACKWARD_EJECT_CORAL_TOP_MOTOR_VOLTAGE = 3;
+  public static final double FOREWARD_EJECT_CORAL_TOP_MOTOR_VOLTAGE = -3;
+  public static final double BACKWARD_EJECT_CORAL_LOW_MOTOR_VOLTAGE = -3;
+  public static final double FOREWARD_EJECT_CORAL_LOW_MOTOR_VOLTAGE = 3;
 
   public static final double INTAKE_ALGAE_LOW_MOTOR_VOLTAGE = -4;
   public static final double EJECT_ALGAE_LOW_MOTOR_VOLTAGE = 3;

--- a/src/main/java/frc/robot/constants/PivotConstants.java
+++ b/src/main/java/frc/robot/constants/PivotConstants.java
@@ -49,7 +49,7 @@ public class PivotConstants {
   /** Maximum speed of pivot in rot per sec */
   public static final double MAX_SPEED = Units.degreesToRotations(189);
 
-/** Maximum acceleration of pivot in rot per sec² */
+  /** Maximum acceleration of pivot in rot per sec² */
   public static final double MAX_ACCELERATION = Units.degreesToRotations(81);
 
   /** */

--- a/src/main/java/frc/robot/constants/PivotConstants.java
+++ b/src/main/java/frc/robot/constants/PivotConstants.java
@@ -46,9 +46,11 @@ public class PivotConstants {
   /** */
   public static final double GEAR_RATIO = 378;
 
-  public static final double MAX_SPEED = 0.525;
+  /** Maximum speed of pivot in rot per sec */
+  public static final double MAX_SPEED = Units.degreesToRotations(189);
 
-  public static final double MAX_ACCELERATION = 0.225;
+/** Maximum acceleration of pivot in rot per sec² */
+  public static final double MAX_ACCELERATION = Units.degreesToRotations(81);
 
   /** */
   public static final ArmFeedforward FF_MODEL =

--- a/src/main/java/frc/robot/constants/PivotConstants.java
+++ b/src/main/java/frc/robot/constants/PivotConstants.java
@@ -46,6 +46,10 @@ public class PivotConstants {
   /** */
   public static final double GEAR_RATIO = 378;
 
+  public static final double MAX_SPEED = 0.525;
+
+  public static final double MAX_ACCELERATION = 0.225;
+
   /** */
   public static final ArmFeedforward FF_MODEL =
       new ArmFeedforward(0.11164, 0.0090459, 0.11954, 0.0090459);

--- a/src/main/java/frc/robot/constants/PositionConstants.java
+++ b/src/main/java/frc/robot/constants/PositionConstants.java
@@ -77,32 +77,35 @@ public class PositionConstants {
   }
 
   // L1 Arm Setpoint Values
-  public static final double L1WristAngle = 42.199999999999996;
-  public static final double L1PivotAngle = 33.10199999999992;
+  public static final double L1WristAngle = 63.11;
+  public static final double L1PivotAngle = 22.81;
   public static final double L1ElevatorExtension = 0;
 
   // L2 Arm Setpoint Values
-  public static final double L2WristAngle = 6.799999999999816;
-  public static final double L2PivotAngle = 72.79999999999995;
+  public static final double L2WristAngle = 39.109999999999985;
+  public static final double L2PivotAngle = 51.82;
   public static final double L2ElevatorExtension = 0;
 
   // L3 Arm Setpoint Values
-  public static final double L3WristAngle = -5.199999999999999;
-  public static final double L3PivotAngle = 76.2;
-  public static final double L3ElevatorExtension = 0.46500000000000263;
+  public static final double L3WristAngle = 22.31;
+  public static final double L3PivotAngle = 61.62;
+  public static final double L3ElevatorExtension = 0.26;
 
   // L4 Arm Setpoint Values
-  public static final double L4WristAngle = 59.94921875000001;
+  public static final double L4WristAngleAuto = 52.74921875000003;
+  public static final double L4PivotAngleAuto = 74.399999999999781;
+
+  public static final double L4WristAngle = 54.349;
   public static final double L4PivotAngle = 74.72634881514921;
   public static final double L4ElevatorExtension = 0.9051441865808824;
 
   // Source Arm Setpoint Values
-  public static final double sourceWristAngle = 108.275;
+  public static final double sourceWristAngle = 111.475;
   public static final double sourcePivotAngle = 65.88248059405254;
   public static final double sourceElevatorExtension = 0;
 
   // Climb Arm Setpoint Values
-  public static final double climbWristAngle = -26.745;
+  public static final double climbWristAngle = 12.4;
   public static final double climbPivotAngle = 24;
   public static final double climbElevatorExtension = 0;
 
@@ -111,15 +114,15 @@ public class PositionConstants {
   public static final double stowPivotAngle = 81.81999599249039;
   public static final double stowElevatorExtension = 0;
 
-  public static final double safePivotPosition = 80.40000000000006;
+  public static final double safePivotPosition = 90.0;
 
-  public static final double lowerAlgaeRemovalPivotAngle = 32.33384351834553;
-  public static final double lowerAlgaeRemovalWristAngle = 90;
+  public static final double lowerAlgaeRemovalPivotAngle = 54.9999999999995;
+  public static final double lowerAlgaeRemovalWristAngle = 143.11;
   public static final double lowerAlgaeRemovalElevatorHeight = 0;
 
-  public static final double upperAlgaeRemovalPivotAngle = 58.533843518345904;
-  public static final double upperAlgaeRemovalWristAngle = 71.60000000000007;
-  public static final double upperAlgaeRemovalElevatorHeight = 0.15000000000000005;
+  public static final double upperAlgaeRemovalPivotAngle = 78.51970529998351;
+  public static final double upperAlgaeRemovalWristAngle = 159.2;
+  public static final double upperAlgaeRemovalElevatorHeight = 0.31000000000000016;
 
   public static final double[][] reefArmPositions = {
     {L1WristAngle, L1PivotAngle, L1ElevatorExtension},
@@ -127,4 +130,8 @@ public class PositionConstants {
     {L3WristAngle, L3PivotAngle, L3ElevatorExtension},
     {L4WristAngle, L4PivotAngle, L4ElevatorExtension}
   };
+
+  public static final double NetWristAngle = 139.11;
+  public static final double NetPivotAngle = 87.81;
+  public static final double NetElevatorExtension = 1.15;
 }

--- a/src/main/java/frc/robot/constants/WristConstants.java
+++ b/src/main/java/frc/robot/constants/WristConstants.java
@@ -22,8 +22,11 @@ public class WristConstants {
   /** ID of the wrist sparkmax */
   public static final int MOTOR_ID = 14;
 
-  public static final double MAX_SPEED = 0.5;
-  public static final double MAX_ACCELERATION = 1.0;
+  /** The maximum speed of the wrist in rot per sec */
+  public static final double MAX_SPEED = Units.degreesToRotations(180);
+
+  /** The maximum acceleration of the wrist in rot per sec² */
+  public static final double MAX_ACCELERATION = Units.degreesToRotations(360);
 
   /** */
   public static final boolean MOTOR_INVERTED = false;

--- a/src/main/java/frc/robot/constants/WristConstants.java
+++ b/src/main/java/frc/robot/constants/WristConstants.java
@@ -22,8 +22,8 @@ public class WristConstants {
   /** ID of the wrist sparkmax */
   public static final int MOTOR_ID = 14;
 
-  public static final double MAX_SPEED = 0.5
-  public static final double MAX_ACCELERATION = 1.0
+  public static final double MAX_SPEED = 0.5;
+  public static final double MAX_ACCELERATION = 1.0;
 
   /** */
   public static final boolean MOTOR_INVERTED = false;

--- a/src/main/java/frc/robot/constants/WristConstants.java
+++ b/src/main/java/frc/robot/constants/WristConstants.java
@@ -22,6 +22,9 @@ public class WristConstants {
   /** ID of the wrist sparkmax */
   public static final int MOTOR_ID = 14;
 
+  public static final double MAX_SPEED = 0.5
+  public static final double MAX_ACCELERATION = 1.0
+
   /** */
   public static final boolean MOTOR_INVERTED = false;
 

--- a/src/main/java/frc/robot/constants/WristConstants.java
+++ b/src/main/java/frc/robot/constants/WristConstants.java
@@ -80,6 +80,9 @@ public class WristConstants {
   /** */
   public static final double ZEROING_VOLTAGE = 1; // TODO tune
 
+  /** Rising debounce time for amperage at max */
+  public static final double ZEROING_DEBOUNCE_TIME = 0.5;
+
   /** */
   public static final double WRIST_ZEROING_MAX_AMPS = 20; // TODO tune
 

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
@@ -47,7 +47,7 @@ public class ElevatorIOReal implements ElevatorIO {
 
     leftMotorConfig.MotionMagic.MotionMagicCruiseVelocity = MAX_SPEED / rotToMetMultFactor;
     leftMotorConfig.MotionMagic.MotionMagicAcceleration = MAX_ACCELERATION / rotToMetMultFactor;
-    leftMotorConfig.MotionMagic.MotionMagicJerk = 0 / rotToMetMultFactor;
+    leftMotorConfig.MotionMagic.MotionMagicJerk = MOTION_MAGIC_JERK / rotToMetMultFactor;
 
     leadingMotor.getConfigurator().apply(leftMotorConfig);
     followingMotor.getConfigurator().apply(rightMotorConfig);

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
@@ -45,8 +45,8 @@ public class ElevatorIOReal implements ElevatorIO {
     leftMotorConfig.Slot0.kI = 0;
     leftMotorConfig.Slot0.kD = 0;
 
-    leftMotorConfig.MotionMagic.MotionMagicCruiseVelocity = 4 / rotToMetMultFactor;
-    leftMotorConfig.MotionMagic.MotionMagicAcceleration = 4 / rotToMetMultFactor;
+    leftMotorConfig.MotionMagic.MotionMagicCruiseVelocity = MAX_SPEED / rotToMetMultFactor;
+    leftMotorConfig.MotionMagic.MotionMagicAcceleration = MAX_ACCELERATION / rotToMetMultFactor;
     leftMotorConfig.MotionMagic.MotionMagicJerk = 0 / rotToMetMultFactor;
 
     leadingMotor.getConfigurator().apply(leftMotorConfig);

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -67,14 +67,35 @@ public class Intake extends SubsystemBase {
   }
 
   /**
-   * Runs the top intake motor at eject voltage specified in {@link IntakeConstants}.
+   * Runs the top intake motor at backwards eject voltage specified in {@link IntakeConstants}.
+   *
+   * @return Command that runs the intake until we no longer sense a coral, then continues for a
+   *     small time.
+   */
+  public Command backEjectCoralCommand() {
+    return runBothMotorsCommand(
+            () -> BACKWARD_EJECT_CORAL_TOP_MOTOR_VOLTAGE,
+            () -> BACKWARD_EJECT_CORAL_LOW_MOTOR_VOLTAGE)
+        .until(() -> !getHasGamePiece().getAsBoolean())
+        .andThen(waitSeconds(EJECT_RELEASE_DELAY))
+        .finallyDo(
+            () -> {
+              intake.setLowMotorVoltage(0);
+              intake.setTopMotorVoltage(0);
+            });
+  }
+
+  /**
+   * Runs the top intake motor at forward eject voltage specified in {@link IntakeConstants}.
    *
    * @return Command that runs the intake until we no longer sense a coral, then continues for a
    *     small time.
    */
   public Command ejectCoralCommand() {
-    return runTopMotorCommand(() -> EJECT_CORAL_TOP_MOTOR_VOLTAGE)
-        .until(getHasGamePiece())
+    return runBothMotorsCommand(
+            () -> FOREWARD_EJECT_CORAL_TOP_MOTOR_VOLTAGE,
+            () -> FOREWARD_EJECT_CORAL_LOW_MOTOR_VOLTAGE)
+        .until(() -> !getHasGamePiece().getAsBoolean())
         .andThen(waitSeconds(EJECT_RELEASE_DELAY))
         .finallyDo(
             () -> {

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -105,6 +105,22 @@ public class Intake extends SubsystemBase {
   }
 
   /**
+   * Runs both motors at forward eject voltage specified in {@link IntakeConstants}.
+   *
+   * @return Command that runs the intake until we terminate.
+   */
+  public Command runEjectCommand() {
+    return runBothMotorsCommand(
+            () -> FOREWARD_EJECT_CORAL_TOP_MOTOR_VOLTAGE,
+            () -> FOREWARD_EJECT_CORAL_LOW_MOTOR_VOLTAGE)
+        .finallyDo(
+            () -> {
+              intake.setLowMotorVoltage(0);
+              intake.setTopMotorVoltage(0);
+            });
+  }
+
+  /**
    * MUST BE TERMINATED EXTERNALLY
    *
    * <p>Runs the lower intake motor at voltage specified in {@link IntakeConstants}.

--- a/src/main/java/frc/robot/subsystems/pivot/PivotIOReal.java
+++ b/src/main/java/frc/robot/subsystems/pivot/PivotIOReal.java
@@ -93,8 +93,8 @@ public class PivotIOReal implements PivotIO {
     leftMotorConfig.Slot0.kI = 0;
     leftMotorConfig.Slot0.kD = 0;
 
-    leftMotorConfig.MotionMagic.MotionMagicCruiseVelocity = GEAR_RATIO * 0.75;
-    leftMotorConfig.MotionMagic.MotionMagicAcceleration = GEAR_RATIO * 0.75;
+    leftMotorConfig.MotionMagic.MotionMagicCruiseVelocity = GEAR_RATIO * MAX_SPEED;
+    leftMotorConfig.MotionMagic.MotionMagicAcceleration = GEAR_RATIO * MAX_ACCELERATION;
     leftMotorConfig.MotionMagic.MotionMagicJerk = 0;
 
     leadingMotor.getConfigurator().apply(leftMotorConfig);

--- a/src/main/java/frc/robot/subsystems/wrist/WristIOReal.java
+++ b/src/main/java/frc/robot/subsystems/wrist/WristIOReal.java
@@ -39,8 +39,8 @@ public class WristIOReal implements WristIO {
     motorConfig.Slot0.kI = 0;
     motorConfig.Slot0.kD = 0;
 
-    motorConfig.MotionMagic.MotionMagicCruiseVelocity = 2500 / MOTOR_RATIO;
-    motorConfig.MotionMagic.MotionMagicAcceleration = 5000 / MOTOR_RATIO;
+    motorConfig.MotionMagic.MotionMagicCruiseVelocity = MAX_SPEED * MOTOR_RATIO;
+    motorConfig.MotionMagic.MotionMagicAcceleration = MAX_ACCELERATION * MOTOR_RATIO;
 
     motorConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
 

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -305,7 +305,8 @@ public class CompoundCommands {
   }
 
   /**
-   * Generates a {@link Command} to move the arm to the specified position, moving all mechanisms simultaneously.
+   * Generates a {@link Command} to move the arm to the specified position, moving all mechanisms
+   * simultaneously.
    *
    * @param wristSetPos Angle in degrees to set the wrist
    * @param pivotSetPos Angle in degrees to set the pivot
@@ -314,9 +315,9 @@ public class CompoundCommands {
    */
   public static Command armToGoal(double wristSetPos, double pivotSetPos, double elevatorSetPos) {
     return pivot
-      .setPosition(() -> pivotSetPos)
-      .alongWith(wrist.setGoalPosition(() -> wristSetPos))
-      .alongWith(elevator.setPosition((() -> elevatorSetPos)))
+        .setPosition(() -> pivotSetPos)
+        .alongWith(wrist.setGoalPosition(() -> wristSetPos))
+        .alongWith(elevator.setPosition((() -> elevatorSetPos)));
   }
 
   /**
@@ -330,7 +331,8 @@ public class CompoundCommands {
    * @param elevatorSetPos Height in meters to set the elevator
    * @return A {@link Command} to set the arm goal position to the specified position
    */
-  public static Command armToGoalSafely(double wristSetPos, double pivotSetPos, double elevatorSetPos) {
+  public static Command armToGoalSafely(
+      double wristSetPos, double pivotSetPos, double elevatorSetPos) {
     if (elevatorSetPos > elevator.getPosition().getAsDouble()) {
       return elevator
           .setPosition(() -> elevatorSetPos)

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -112,7 +112,7 @@ public class CompoundCommands {
         new ParallelCommandGroup(driveCommand, armToReefAvoidAlgae(level)).withTimeout(5.0);
 
     // Small wait to ensure arm is stable before shooting
-    return alignCommand.andThen(waitSeconds(0.5)).andThen(intakeCoral());
+    return alignCommand.andThen(waitSeconds(0.5)).andThen(ejectCoral());
   }
 
   public static Command armToReefAvoidAlgae(int reefLevel) {

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -131,7 +131,7 @@ public class CompoundCommands {
         new ParallelCommandGroup(driveCommand, armToReefSafely(level)).withTimeout(5.0);
 
     // Small wait to ensure arm is stable before shooting
-    return alignCommand.andThen(waitSeconds(0.5)).andThen(intakeCoral());
+    return alignCommand.andThen(waitSeconds(0.5)).andThen(ejectCoral());
   }
 
   public static Command intakeSource(boolean isOnRight) {

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -283,6 +283,21 @@ public class CompoundCommands {
   }
 
   /**
+   * Generates a {@link Command} to move the arm to the specified position, moving all mechanisms simultaneously.
+   *
+   * @param wristSetPos Angle in degrees to set the wrist
+   * @param pivotSetPos Angle in degrees to set the pivot
+   * @param elevatorSetPos Height in meters to set the elevator
+   * @return A {@link Command} to set the arm goal position to the specified position
+   */
+  public static Command armToGoal(double wristSetPos, double pivotSetPos, double elevatorSetPos) {
+    return pivot
+      .setPosition(() -> pivotSetPos)
+      .alongWith(wrist.setGoalPosition(() -> wristSetPos))
+      .alongWith(elevator.setPosition((() -> elevatorSetPos)))
+  }
+
+  /**
    * Generates a {@link Command} to move the arm to the specified position, ensuring to always stay
    * in frame perimeter. If the goal position needs the elevator to extend, we first move pivot,
    * then move the elevator and wrist. Otherwise, if the goal position needs the elevator to retract
@@ -293,8 +308,7 @@ public class CompoundCommands {
    * @param elevatorSetPos Height in meters to set the elevator
    * @return A {@link Command} to set the arm goal position to the specified position
    */
-  public static Command armToGoal(double wristSetPos, double pivotSetPos, double elevatorSetPos) {
-
+  public static Command armToGoalSafely(double wristSetPos, double pivotSetPos, double elevatorSetPos) {
     if (elevatorSetPos > elevator.getPosition().getAsDouble()) {
       return elevator
           .setPosition(() -> elevatorSetPos)

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -138,6 +138,10 @@ public class CompoundCommands {
         reefArmPositions[reefLevel - 1][2]);
   }
 
+  public static Command armToNet() {
+    return armToGoal(NetWristAngle, NetPivotAngle, NetElevatorExtension);
+  }
+
   public static Command armToAlgae(boolean upper) {
     if (upper) {
       return armToGoal(

--- a/src/main/java/frc/robot/util/CompoundCommands.java
+++ b/src/main/java/frc/robot/util/CompoundCommands.java
@@ -109,7 +109,7 @@ public class CompoundCommands {
         new ParallelCommandGroup(driveCommand, armToReefSafely(level)).withTimeout(5.0);
 
     // Small wait to ensure arm is stable before shooting
-    return alignCommand.andThen(waitSeconds(0.5)).andThen(ejectCoral());
+    return alignCommand.andThen(waitSeconds(0.5)).andThen(intakeCoral());
   }
 
   public static Command intakeSource(boolean isOnRight) {


### PR DESCRIPTION
Tweaks made at DCMP, including:
- Auto routine adjustments
- Remove problematic & redundant logger init in `Robot`
- Remove arm rezeroing at teleop
- Zero arm after shooting
- Adjust positions
- Add bindings to manipulate algae, add net arm position
- Debounce wrist current and log when rezeroing
- Adjust speeds of arm mechanisms
- Move all arm mechanisms simultaneously
- "Intake" instead of "ejecting" when auto placing, so we don't launch coral away
- Avoid algae when placing at the reef (this didn't work very well)
- Add immobile auto for pit testing

TODO:

- [X] Basic functions test on Nautilus
- [x] Confirm desired behavior for eject on Nautilus