### PR TITLE
Delete old logs when running low on space to ensure we don't lose logging

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,11 +4,16 @@
 
 package frc.robot;
 
+import static frc.robot.constants.GeneralConstants.LOG_DIRECTORY_PATH;
+import static frc.robot.constants.GeneralConstants.LOG_SPACE_REQUIREMENT;
 import static frc.robot.constants.GeneralConstants.currentMode;
 
 import com.pathplanner.lib.commands.PathfindingCommand;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
@@ -29,8 +34,38 @@ public class Robot extends LoggedRobot {
     switch (currentMode) {
       case REAL:
         // Running on a real robot, log to a USB stick ("/U/logs")
-        Logger.addDataReceiver(new WPILOGWriter("/U/logs"));
+        Logger.addDataReceiver(new WPILOGWriter(LOG_DIRECTORY_PATH));
         Logger.addDataReceiver(new NT4Publisher());
+
+        // Clear out older logs when running out of space
+        File logDirectory = new File(LOG_DIRECTORY_PATH);
+        long freeSpace = logDirectory.getUsableSpace();
+
+        File[] logs = logDirectory.listFiles();
+        Arrays.sort(logs, Comparator.comparingLong(File::lastModified));
+
+        int i = 0;
+        long newSpace = 0;
+        while (freeSpace < LOG_SPACE_REQUIREMENT) {
+          long fileSize = logs[i].length();
+          logs[i].delete();
+
+          freeSpace += fileSize;
+          newSpace += fileSize;
+          i++;
+        }
+
+        if (i > 0) {
+          System.out.println(
+              "WARNING: Ran out of space for logs and deleted "
+                  + i
+                  + " log files, amounting to "
+                  + newSpace
+                  + "bytes freed. There are currently "
+                  + freeSpace
+                  + " bytes free.");
+        }
+
         break;
 
       case SIM:

--- a/src/main/java/frc/robot/constants/GeneralConstants.java
+++ b/src/main/java/frc/robot/constants/GeneralConstants.java
@@ -47,5 +47,6 @@ public class GeneralConstants {
    * The minimum space available on the log USB drive. If this space is not available, logs will be
    * deleted on init until there is space available.
    */
-  public static final long LOG_SPACE_REQUIREMENT = (long) (0.05 * 1073741824); // Convert Gb to Bytes
+  public static final long LOG_SPACE_REQUIREMENT =
+      (long) (0.05 * 1073741824); // Convert Gb to Bytes
 }

--- a/src/main/java/frc/robot/constants/GeneralConstants.java
+++ b/src/main/java/frc/robot/constants/GeneralConstants.java
@@ -47,5 +47,5 @@ public class GeneralConstants {
    * The minimum space available on the log USB drive. If this space is not available, logs will be
    * deleted on init until there is space available.
    */
-  public static final long LOG_SPACE_REQUIREMENT = (long) (0.5 * 1073741824); // Convert Gb to Bytes
+  public static final long LOG_SPACE_REQUIREMENT = (long) (0.05 * 1073741824); // Convert Gb to Bytes
 }

--- a/src/main/java/frc/robot/constants/GeneralConstants.java
+++ b/src/main/java/frc/robot/constants/GeneralConstants.java
@@ -48,5 +48,5 @@ public class GeneralConstants {
    * deleted on init until there is space available.
    */
   public static final long LOG_SPACE_REQUIREMENT =
-      (long) (0.05 * 1073741824); // Convert Gb to Bytes
+      (long) (0.50 * 1073741824); // Convert Gb to Bytes
 }

--- a/src/main/java/frc/robot/constants/GeneralConstants.java
+++ b/src/main/java/frc/robot/constants/GeneralConstants.java
@@ -40,4 +40,12 @@ public class GeneralConstants {
   }
 
   public static final double UPDATE_PERIOD = 0.02;
+
+  public static final String LOG_DIRECTORY_PATH = "/U/logs";
+
+  /**
+   * The minimum space available on the log USB drive. If this space is not available, logs will be
+   * deleted on init until there is space available.
+   */
+  public static final long LOG_SPACE_REQUIREMENT = (long) (0.5 * 1073741824); // Convert Gb to Bytes
 }


### PR DESCRIPTION
After First Chance E4 on Sunday, we realized that almost all our log files from that day were empty. We determined that this was due to forgetting to clear out old logs. With this change, once we are under a certain amount of free space on the USB drive, we'll begin deleting older logs on init to ensure we can fit logs for new matches.

TODO:
- [ ] Test on Nautilus
- [ ] Determine appropriate minimum space requirement